### PR TITLE
Update heat.m

### DIFF
--- a/classes/heat.m
+++ b/classes/heat.m
@@ -723,7 +723,8 @@ classdef heat < simulation
             
             disp('Calculating _energyMap_ ...')
             tic
-    
+            
+            initTemp        = obj.checkInitialTemperature(initTemp); % check the intial temperature
             energyMap       = zeros(size(tempMap));
             intHeatCapacity = obj.S.getUnitCellPropertyVector('intHeatCapacity');
             normMasses      = obj.S.getUnitCellPropertyVector('mass');              % generates vector of unit cell mass per ang^2 !!
@@ -734,7 +735,7 @@ classdef heat < simulation
             for k=1:obj.S.numSubSystems
                 for i=1:size(tempMap,1)
                     for n=1:obj.S.getNumberOfUnitCells
-                        energyMap(i,n,k) = UCmasses(n)*( intHeatCapacity{n,k}(tempMap(i,n,k)) - intHeatCapacity{n,k}(initTemp) );
+                        energyMap(i,n,k) = UCmasses(n)*( intHeatCapacity{n,k}(tempMap(i,n,k)) - intHeatCapacity{n,k}(initTemp(n,k)) );
                     end
                 end
             end

--- a/classes/heat.m
+++ b/classes/heat.m
@@ -731,10 +731,10 @@ classdef heat < simulation
             bAxes           = obj.S.getUnitCellPropertyVector('bAxis');
             UCmasses        = normMasses.*(aAxes/1e-10).*(bAxes/1e-10);             % calculates vector of unit cell masses
 
-            for s=1:obj.S.numSubSystems
-                for d=1:size(tempMap,1)
-                    for i=1:obj.S.getNumberOfUnitCells
-                        energyMap(d,i,s) = UCmasses(i)*( intHeatCapacity{i,s}(tempMap(d,i,s)) - intHeatCapacity{i,s}(initTemp) );
+            for k=1:obj.S.numSubSystems
+                for i=1:size(tempMap,1)
+                    for n=1:obj.S.getNumberOfUnitCells
+                        energyMap(i,n,k) = UCmasses(n)*( intHeatCapacity{n,k}(tempMap(i,n,k)) - intHeatCapacity{n,k}(initTemp) );
                     end
                 end
             end
@@ -791,11 +791,11 @@ classdef heat < simulation
             volumes             = obj.S.getUnitCellPropertyVector('volume');
             areas               = obj.S.getUnitCellPropertyVector('area');
 
-            for s=1:obj.S.numSubSystems
-                for d=1:length(time)
-                    for i=1:obj.S.getNumberOfUnitCells
-                        energyFluxMap(d,i,s,1) = UCmasses(i) .* heatCapacity{i,s}(tempMap(d,i,s)) .* deltaTempMap(d,i,s) ./ diffTime(d);
-                        energyFluxMap(d,i,s,2) = volumes(i) .* subSystemCoupling{i,s}([tempMap(d,i,1), tempMap(d,i,2)]);
+            for k=1:obj.S.numSubSystems
+                for i=1:length(time)
+                    for n=1:obj.S.getNumberOfUnitCells
+                        energyFluxMap(i,n,k,1) = UCmasses(n) .* heatCapacity{n,k}(tempMap(i,n,k)) .* deltaTempMap(i,n,k) ./ diffTime(i);
+                        energyFluxMap(i,n,k,2) = volumes(n) .* subSystemCoupling{n,k}([tempMap(i,n,1), tempMap(i,n,2)]);
                     end
                 end
             end


### PR DESCRIPTION
calcEnergyMap has been recast into a more performant version. getEnergyMap has been added which stores results to the cache directory and reloads them in subsequent simulations with identical parameters.

For some reasons parfor does not work properly, so it is omitted fo rnow. Needs to be checked in the near future.