### PR TITLE
Generalization of thermCond in heat.m

### DIFF
--- a/classes/heat.m
+++ b/classes/heat.m
@@ -635,7 +635,7 @@ classdef heat < simulation
             index = finderb(z,dStart);
             unitCell = handles{index}; % this is the handle to the corresponding unitCell
             
-            k = cellfun(@feval,(unitCell.thermCond)',num2cell(T));            
+            k = cellfun(@feval,(unitCell.thermCond)',repmat({T},K,1));            
             % these are the parameters of the differential equation as they
             % are defined in matlab for the pdesolver
             

--- a/classes/heat.m
+++ b/classes/heat.m
@@ -734,7 +734,7 @@ classdef heat < simulation
             Cells           = obj.S.getNumberOfUnitCells;
 
             for k=1:obj.S.numSubSystems
-                parfor i=1:size(tempMap,1)
+                for i=1:size(tempMap,1)
                     for n=1:Cells
                         energyMap(i,n,k) = UCmasses(n)*( intHeatCapacity{n,k}(tempMap(i,n,k)) - intHeatCapacity{n,k}(initTemp(n,k)) );
                     end

--- a/classes/heat.m
+++ b/classes/heat.m
@@ -44,7 +44,7 @@ classdef heat < simulation
             obj.heatDiffusion   = p.Results.heatDiffusion;
             obj.intpAtInterface = p.Results.intpAtInterface;
             % set default ode options after initialization of parent class
-            obj.odeOptions.RelTol = 1e-3;
+            obj.odeOptions.RelTol = 1e-4;
         end%function
         
         %% Display


### PR DESCRIPTION
Modifications in pdeHeatEquation() to allow for using every subsystem temperature in each subsystem definition of thermCond. The analytical function can now use T(1),...,T(N) in each of the subsystems. This is in analogy to the usage in the property subsytemCoupling where the diference T(2)-T(1) has to be evaluated.