### PR TITLE
Severe performance improvement in onlyheat calculations of strainMap

### DIFF
--- a/classes/heat.m
+++ b/classes/heat.m
@@ -731,11 +731,10 @@ classdef heat < simulation
             aAxes           = obj.S.getUnitCellPropertyVector('aAxis');
             bAxes           = obj.S.getUnitCellPropertyVector('bAxis');
             UCmasses        = normMasses.*(aAxes/1e-10).*(bAxes/1e-10);             % calculates vector of unit cell masses
-            Cells           = obj.S.getNumberOfUnitCells;
 
             for k=1:obj.S.numSubSystems
                 for i=1:size(tempMap,1)
-                    for n=1:Cells
+                    for n=1:obj.S.getNumberOfUnitCells
                         energyMap(i,n,k) = UCmasses(n)*( intHeatCapacity{n,k}(tempMap(i,n,k)) - intHeatCapacity{n,k}(initTemp(n,k)) );
                     end
                 end

--- a/classes/heat.m
+++ b/classes/heat.m
@@ -635,7 +635,7 @@ classdef heat < simulation
             index = finderb(z,dStart);
             unitCell = handles{index}; % this is the handle to the corresponding unitCell
             
-            k = cellfun(@feval,(unitCell.thermCond)',num2cell(T));            
+            k = cellfun(@feval,(unitCell.thermCond)',repmat({T},K,1));            
             % these are the parameters of the differential equation as they
             % are defined in matlab for the pdesolver
             

--- a/classes/heat.m
+++ b/classes/heat.m
@@ -734,7 +734,7 @@ classdef heat < simulation
             Cells           = obj.S.getNumberOfUnitCells;
 
             for k=1:obj.S.numSubSystems
-                parfor i=1:size(tempMap,1)
+                for i=1:size(tempMap,1)
                     for n=1:Cells
                         energyMap(i,n,k) = UCmasses(n)*( intHeatCapacity{n,k}(tempMap(i,n,k)) - intHeatCapacity{n,k}(initTemp(n,k)) );
                     end

--- a/classes/heat.m
+++ b/classes/heat.m
@@ -44,7 +44,7 @@ classdef heat < simulation
             obj.heatDiffusion   = p.Results.heatDiffusion;
             obj.intpAtInterface = p.Results.intpAtInterface;
             % set default ode options after initialization of parent class
-            obj.odeOptions.RelTol = 1e-3;
+            obj.odeOptions.RelTol = 1e-4;
         end%function
         
         %% Display

--- a/classes/phonon.m
+++ b/classes/phonon.m
@@ -183,7 +183,10 @@ classdef phonon < simulation
                     % current temperature for each subsystem                        
                     % traverse subsystems
                     for j=1:K
-                        intAlphaT(:,j) = cellfun(@feval,intLinThermExps(:,j),num2cell(squeeze(tempMap(i,:,j))'));
+                        % traverse unit cells
+                        for n=1:N
+                            intAlphaT(n,j) = intLinThermExps{n,j}(tempMap(i,n,j));      % cellfun(@feval,intLinThermExps(:,j),num2cell(squeeze(tempMap(i,:,j))'));
+                        end
                     end%for
 
                     % calculate the length of the sticks of each subsystem and sum


### PR DESCRIPTION
Similar to calcEnergyMap(), it is much more efficient not to vectorize the calculation of the sticks in a onlyheat calculation (no coherent strain response, only adiabatic strain response to stress). The usage of @feval seems to slow down the calculation severely. A test calculation is 7 times faster when using an explicit for-loop for traversing the individual unit cells.

Sorry for the other changes. These are personal changes that do not need to find its way into the upstream.